### PR TITLE
run program for time specified and handle runtime errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,50 @@ This is an experimental Instagram bot created to be used to help users tag
 their friends in posts. It uses the Instagram API to make HTTPS requests and
 doesn't need either Selenium or a browser to be used. 
 
-[more info incoming as project progresses]
+## Requirements
+* Python
+* Docker (optional)
+
+## Instructions
+*  First clone the project
+    ```shell
+   $ git clone git@github.com:pkarakal/instabot.git
+    ``` 
+   
+### Natively
+If you choose to run this natively, follow the below instructions:
+
+*  Install python libraries necessary
+    ```shell
+   $ pip install -r requirements.txt
+    ```
+*  Replace the necessary fields in file.yaml with your desired values
+*  Run the program using
+   ```shell
+   $ python -m instabot -f file.yaml
+   ```
+*  Alternatively, you can use cli arguments, but it isn't recommended mostly
+   for security reasons. To see the arguments the program takes, type
+   ```shell
+   $ python -m instabot --help
+   ```
+   
+### Docker
+If you choose to run this in a container, follow the instructions below.
+*  Replace the necessary fields in file.yaml with your desired values
+*  Build the image
+   ```shell
+   $ docker build -t instabot:latest . 
+   ```
+*  Create and run the container
+   ```shell
+  $ docker run --name instabot -d instabot:latest
+   ```
+*  If you choose to go with cli arguments, just build the dockerfile with cli using
+   ```shell
+   $ docker build -t instabot:cli -f Dockerfile.cli .
+   ```
+*  Create and run the container
+   ```shell
+  $ docker run --name instabot -d instabot:latest python -m instabot [ARGS]
+   ```

--- a/instabot/SpamDetectedException.py
+++ b/instabot/SpamDetectedException.py
@@ -1,0 +1,9 @@
+class SpamDetectedException(Exception):
+    def __init__(self, parameter, message="Comments are blocked until \'{parameter}\'. This is greater than 7 days. "
+                                          "Exiting..."):
+        self.parameter = parameter
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return self.message.format(parameter=self.parameter)

--- a/instabot/__main__.py
+++ b/instabot/__main__.py
@@ -1,14 +1,18 @@
 import instabot.cli_parser as cli_parser
 from instabot.instagram import Instagram
+from datetime import datetime
 import sys
 
 if __name__ == "__main__":
     parser = cli_parser.Parser()
     cli = parser.parseCLI(sys.argv[1:])
     if cli.get('username') is not None and cli.get('password') is not None:
+        termination = cli.get('run_until')
+        termination_date = datetime.fromisoformat(termination)
+        comments_per_day = cli.get('comments-per-day') or 500
         insta = Instagram(cli.get('tags'))
         (session, cookies) = insta.login(cli.get('username'), cli.get('password'))
         insta.post_comment(post_id=cli.get('post-id')[0], token=session.get('csrf_token'),
                            comment=" ".join(insta.randomizeTags(
-                               int(cli.get('number-of-tags')) if cli.get('number-of-tags') is not None else cli.get(
-                                   'number_of_tags'))))
+                               int(cli.get('number_of_tags')) if cli.get('number_of_tags') is not None else None)),
+                           run_until=termination_date, comments_per_day=comments_per_day)

--- a/instabot/cli_parser.py
+++ b/instabot/cli_parser.py
@@ -11,12 +11,15 @@ class Parser:
                                help="define the post id to post the comment to")
         self.parser.add_option("-t", "--tags", action="append", dest="tags",
                                help="define the username of the users to tag in the post")
-        self.parser.add_option("-a", "--authentication-token", dest="token", help="define your authentication token")
         self.parser.add_option("-n", "--number-of-tags", dest="number_of_tags",
                                help="define the number of tags you want in each comment")
         self.parser.add_option("-f", "--file", dest="file", help="define the yaml file to read parameters from")
         self.parser.add_option("-u", "--username", dest="username", help="define your username")
         self.parser.add_option("-p", "--password", dest="password", help="define your password")
+        self.parser.add_option("-r", "--run-until", dest="run_until", help="define the datetime to stop program "
+                                                                           "execution")
+        self.parser.add_option("-c", "--comments-per-day", dest="comments_per_day", help="define how many comments "
+                                                                                         "per day to post")
 
     def parseCLI(self, arguments=None):
         if arguments is None:


### PR DESCRIPTION
Close #8 

This adds 2 new arguments to the cli options for parsing run-until and comments-per-day while also removing authentication_token as all the cookies obtained at login time are mandatory to make the requests. 

Closes #3 

This also adds the functionality to run the program until the datetime specified in the parameters while making x=comments-per-day comments. If used carefully, the SpamDetected exception may not even be raised during program execution.
If an error is returned from Instagram API, It searches for the 2 most common return messages (one after spam detected and the other when being put in time-out) and sleeps for the according time. If that time is greater than 7 seven days, exit. 
