### PR TITLE
fix(encoding): try converting cp1252 files to utf-8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests >= 2.25.1
 PyYAML >= 5.4.1
 pyinstaller >= 4.3
+chardet >= 4.0.0


### PR DESCRIPTION
If UnicodeDecodeError is thrown, it tries to recover from it by converting files to UTF-8 by copying bytes from one file to the other using chardet to detect encoding.  

Fix #18 